### PR TITLE
Feature/mdc mplat 1209 buildkite plugin for GitHub access tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ We then use this plugin to run the **pre-checkout** hooks that will contact the 
 
 ### Requirements
 The plugin assumes the following Buildkite Secrets are defined in the Buildkite agent dashboard for the queues running the agent:
+
 - GITHUB_BUILDKITE_AUTH_APP_CLIENT_ID
 - GITHUB_BUILDKITE_AUTH_APP_PRIVATE_KEY
 - GITHUB_BUILDKITE_AUTH_APP_INSTALL_ID
+
 If these are not available, the plugin will fail to run.
 
 ### Usage

--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
 # github-access-token-buildkite-plugin
 A Buildkite Plugin for authenticating buildkite-agents with Github using a Github App and short-lived tokens.
+
+## Purpose
+This plugin provides a repeatable and declarative way to add Git credentials authorization between a host running a **buildkite_agent** and the MM Github Enterprise account.  We achieve this by having a Github App -- https://github.com/organizations/modmed/settings/apps/buildkite-auth-app -- that gives the **Contents** permission for each repo we need to be able to clone from Buildkite.
+
+We then use this plugin to run the **pre-checkout** hooks that will contact the Github App and create a temporary access token.  This agent is then updated to use this token for subsequent git operations.
+
+### Requirements
+The plugin assumes the following Buildkite Secrets are defined in the Buildkite agent dashboard for the queues running the agent:
+- GITHUB_BUILDKITE_AUTH_APP_CLIENT_ID
+- GITHUB_BUILDKITE_AUTH_APP_PRIVATE_KEY
+- GITHUB_BUILDKITE_AUTH_APP_INSTALL_ID
+If these are not available, the plugin will fail to run.
+
+### Usage
+
+Add the following to the pipeline YAML file whose corresponding repo is hosted in the MM Github Enterprise account:
+
+```
+steps:
+  - label: ":xcode: Build"
+    command: xcodebuild | xcbeautify
+    env:
+      BUILDKITE_PLUGINS_ALWAYS_CLONE_FRESH: "false" # Make true if debugging
+    plugins:
+      - modmed-public/github-access-token#v1.0.0
+    agents:
+      queue: "some-queue"
+```

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -132,7 +132,7 @@ if [ "$protocol" = "HTTPS" ]; then
     https_token=$(make-access-token "${installation_id}" "$generated_jwt")
     print_redacted "${https_token}"
     echo "Modifying gitconfig for HTTPS"
-    git config --global url."https://x-access-token:$token@github.com/".insteadOf "https://github.com"
+    git config --global url."https://x-access-token:$https_token@github.com/".insteadOf "https://github.com"
 fi
 
 exit 0

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -1,0 +1,138 @@
+#!/bin/bash
+
+# Purpose:
+# grab the jwt token
+# get a normal token from it
+# use git config globally to always use this token, even instead of ssh
+
+# https://github.com/organizations/modmed/settings/apps/buildkite-auth-app
+
+make-jwt() {
+    client_id=$1 # Client ID as first argument
+    pem=$2 # private key as second argument
+
+    now=$(date +%s)
+    iat=$((${now} - 60)) # Issues 60 seconds in the past
+    exp=$((${now} + 600)) # Expires 10 minutes in the future
+
+    b64enc() { openssl base64 | tr -d '=' | tr '/+' '_-' | tr -d '\n'; }
+
+    header_json='{
+        "typ":"JWT",
+        "alg":"RS256"
+    }'
+    # Header encode
+    header=$( echo -n "${header_json}" | b64enc )
+
+    payload_json="{
+        \"iat\":${iat},
+        \"exp\":${exp},
+        \"iss\":\"${client_id}\"
+    }"
+    # Payload encode
+    payload=$( echo -n "${payload_json}" | b64enc )
+
+    # Signature
+    header_payload="${header}"."${payload}"
+    signature=$(
+        openssl dgst -sha256 -sign <(echo -n "${pem}") \
+        <(echo -n "${header_payload}") | b64enc
+    )
+
+    # Create JWT
+    JWT="${header_payload}"."${signature}"
+    #printf '%s\n' "JWT: $JWT"
+    echo $JWT
+}
+
+make-access-token() {
+    local installation_id=$1 # installation id as first argument
+    local generated_jwt=$2 # JWT as second argument
+    local github_api_url="https://api.github.com/app"
+
+    # call the urls with it
+    #echo "Calling [${github_api_url}], result:"
+    curl -s \
+    -H "Authorization: Bearer ${generated_jwt}" \
+    -H "Accept: application/vnd.github.machine-man-preview+json" \
+    "${github_api_url}" > /dev/null
+
+    github_api_url="https://api.github.com/app/installations"
+    #echo "Calling [${github_api_url}], result:"
+    curl -s \
+    -H "Authorization: Bearer ${generated_jwt}" \
+    -H "Accept: application/vnd.github.v3+json" \
+    "${github_api_url}" > /dev/null
+
+    # get the token by POSTING to the url:
+    github_api_url="https://api.github.com/app/installations/$installation_id/access_tokens"
+    #echo "Calling [${github_api_url}], result:"
+    local tokens=$(curl -s -X POST \
+    -H "Authorization: Bearer ${generated_jwt}" \
+    -H "Accept: application/vnd.github.v3+json" \
+    "${github_api_url}" )
+
+    # extract the token, more information about expiry for example is present as well:
+    local token=$(echo "$tokens" | jq -r '.token')
+    echo $token
+}
+
+check_git_url_protocol() {
+  local git_url="$1"
+
+  if [[ "$git_url" =~ ^git@ ]]; then
+    echo "SSH"
+  elif [[ "$git_url" =~ ^https:// ]]; then
+    echo "HTTPS"
+  else
+    echo "Unknown"
+  fi
+}
+
+print_redacted() {
+  local name="$1"
+  local redacted="${name:0:4}****************"
+  echo "(redacted): $redacted"
+}
+
+echo "Will prepare access token(s) for $BUILDKITE_REPO"
+protocol=$(check_git_url_protocol $BUILDKITE_REPO)
+echo "Git URL protocol being used is $protocol"
+echo "Gathering Secrets..."
+
+client_id="$(buildkite-agent secret get GITHUB_BUILDKITE_AUTH_APP_CLIENT_ID)"
+private_key="$(buildkite-agent secret get GITHUB_BUILDKITE_AUTH_APP_PRIVATE_KEY)"
+installation_id="$(buildkite-agent secret get GITHUB_BUILDKITE_AUTH_APP_INSTALL_ID)"
+
+echo "client_id:"
+print_redacted  "${client_id}"
+echo "private_key:"
+print_redacted  "${private_key}"
+echo "installation_id:"
+print_redacted  "${installation_id}"
+
+if [[ -z "${client_id}" || -z "${private_key}" || -z "${installation_id}" ]]; then
+    buildkite-agent annotate 'Buildkite Secrets for GITHUB_BUILDKITE_AUTH_APP_CLIENT_ID, GITHUB_BUILDKITE_AUTH_APP_PRIVATE_KEY, or GITHUB_BUILDKITE_AUTH_APP_INSTALL_ID empty or unset so skipping token setup.' --style 'error' --context 'ctx-error'
+    exit 1
+fi
+
+echo "Generating JWT:"
+generated_jwt=$(make-jwt "$client_id"  "$private_key")
+print_redacted "${generated_jwt}"
+
+echo "Generating Access Token:"
+token=$(make-access-token "${installation_id}" "$generated_jwt")
+print_redacted "${token}"
+
+echo "Modifying gitconfig for SSH"
+git config --global url."https://x-access-token:$token@github.com/".insteadOf "git@github.com:"
+
+if [ "$protocol" = "HTTPS" ]; then
+    echo "Creating another token for HTTPS specifically..."
+    https_token=$(make-access-token "${installation_id}" "$generated_jwt")
+    print_redacted "${https_token}"
+    echo "Modifying gitconfig for HTTPS"
+    git config --global url."https://x-access-token:$token@github.com/".insteadOf "https://github.com"
+fi
+
+exit 0

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+filepath="$(realpath ~/.gitconfig)"
+echo "Deleting ${filepath}"
+
+# clean up global configuration so we don't leave the token around
+#git config --global --remove-section url."https://x-access-token:$GITHUB_BUILDKITE_AUTH_APP_TOKEN@github.com/"
+
+rm ${filepath} || true
+
+exit 0

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,0 +1,9 @@
+name: Modmed Github Authenticator for Buildkite
+description: A Buildkite Plugin for authenticating buildkite-agents with Github using a Github App and short-lived tokens.
+author: https://github.com/modmed-public
+requirements: []
+configuration:
+  properties:
+    pattern:
+      type: string
+  additionalProperties: false

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,9 +1,7 @@
 name: Modmed Github Authenticator for Buildkite
-description: A Buildkite Plugin for authenticating buildkite-agents with Github using a Github App and short-lived tokens.
+description: A Buildkite Plugin for authenticating buildkite-agents with Github using a Github App and short-lived access tokens.
 author: https://github.com/modmed-public
 requirements: []
 configuration:
-  properties:
-    pattern:
-      type: string
+  properties: []
   additionalProperties: false


### PR DESCRIPTION
Defines a Buildkite plugin that we can use with our pipelines to retrieve an access token from our Github app at _https://github.com/organizations/modmed/settings/apps/buildkite-auth-app_

After receiving the token it modifies the .**gitconfig** file to redirect git urls to use the token for authentication.  This is being done on the **buildkite_agent** host machine. This allows the agent to make git clone requests to our GHE account without there being an actual user account for the agent.

This plugin is hosted on our public Github because it must be accessible outside of our GHE accounts.  No sensitive information and/or keys must be added here -- nothing hard coded.  Any secrets are being pulled from the Buildkite secrets manager.